### PR TITLE
Supporting custom path-host along with path-regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vulcan-config-builder
+*.idea
+*.exe
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ etcdctl set   /ft/services/service-a/healthcheck      true
 etcdctl set   /ft/services/service-a/servers/1        "http://host:5678"
 etcdctl set   /ft/services/service-a/path-regex/foo   /foo/.*
 etcdctl set   /ft/services/service-a/path-regex/bar   /bar/.*
+etcdctl set   /ft/services/service-a/path-host/bar  public-host
 etcdctl set   /ft/services/service-a/failover         "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1" //default failover value if /ft/services/service-a/failover key is missing is empty
 ```
 
@@ -35,10 +36,14 @@ will result in
 # host header based routing
 /vulcand/frontends/vcb-byhostheader-service-a/frontend         {"Type":"http", "BackendId":"vcb-service-a", "Route":"PathRegexp(`/.*`) && Host(`service-a`)", "Settings": {"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1"}}
 
+# etcdctl set   /ft/services/service-a/path-regex/foo   /foo/.*
 # "public" routing
 /vulcand/frontends/vcb-service-a-path-regex-foo/frontend  {"Type":"http", "BackendId":"vcb-service-a", "Route":"PathRegexp(`/foo/.*`)", "Settings": {"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1"}}
-/vulcand/frontends/vcb-service-a-path-regex-bar/frontend  {"Type":"http", "BackendId":"vcb-service-a", "Route":"PathRegexp(`/bar/.*`)", "Settings": {"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1"}}
 
+# etcdctl set   /ft/services/service-a/path-regex/bar   /bar/.*
+# etcdctl set   /ft/services/service-a/path-host/bar  public-host
+# "public" routing with custom header
+/vulcand/frontends/vcb-service-a-path-regex-bar/frontend  {"Type":"http", "BackendId":"vcb-service-a", "Route":"PathRegexp(`/bar/.*`) && Host(`public-host`)", "Settings": {"FailoverPredicate":"(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1"}}
 ```
 
 These routing rules will change as we develop. The idea is they are in a single place in this application, not spread out across many unmaintainable sidekick services.

--- a/all_test.go
+++ b/all_test.go
@@ -28,7 +28,7 @@ func TestReadServices(t *testing.T) {
 		"/ft/services/service-b/servers/srv2":       "http://host2:80",
 		"/ft/services/service-b/path-regex/content": "/content/.*",
 		"/ft/services/service-b/path-regex/bananas": "/bananas/.*",
-		"/ft/services/service-b/path-host/bananas": "custom-host",
+		"/ft/services/service-b/path-host/bananas":  "custom-host",
 		"/ft/services/service-b/failover-predicate": "IsNetworkError()",
 	}); err != nil {
 		t.Error(err)
@@ -67,7 +67,7 @@ func TestReadServices(t *testing.T) {
 			"bananas": "/bananas/.*",
 			"content": "/content/.*",
 		},
-		CustomHosts: map[string]string {
+		CustomHosts: map[string]string{
 			"bananas": "custom-host",
 		},
 		FailoverPredicate: "IsNetworkError()",
@@ -173,7 +173,7 @@ func TestBuildVulcanConfSingleBackend(t *testing.T) {
 			"bananas": "/bananas/.*",
 			"cheese":  "/cheese/.*",
 		},
-		CustomHosts: map[string]string {
+		CustomHosts: map[string]string{
 			"bananas": "custom-host",
 		},
 		FailoverPredicate: "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1",
@@ -342,9 +342,9 @@ func TestApplyVulcanConfigCreate(t *testing.T) {
 		},
 		FrontEnds: map[string]vulcanFrontend{
 			"vcb-byhostheader-service-a": vulcanFrontend{
-				BackendID:         "vcb-service-a",
-				Route:             "PathRegexp(`/.*`) && Host(`service-a`)",
-				Type:              "http",
+				BackendID: "vcb-service-a",
+				Route:     "PathRegexp(`/.*`) && Host(`service-a`)",
+				Type:      "http",
 			},
 			"vcb-health-service-a-srv1": vulcanFrontend{
 				BackendID: "vcb-service-a-srv1",
@@ -361,9 +361,9 @@ func TestApplyVulcanConfigCreate(t *testing.T) {
 				},
 			},
 			"vcb-service-a-path-regex-bananas": vulcanFrontend{
-				BackendID:         "vcb-service-a",
-				Route:             "PathRegexp(`/bananas/.*`)",
-				Type:              "http",
+				BackendID: "vcb-service-a",
+				Route:     "PathRegexp(`/bananas/.*`)",
+				Type:      "http",
 			},
 			"vcb-service-a-path-regex-toast": vulcanFrontend{
 				BackendID:         "vcb-service-a",

--- a/all_test.go
+++ b/all_test.go
@@ -28,6 +28,7 @@ func TestReadServices(t *testing.T) {
 		"/ft/services/service-b/servers/srv2":       "http://host2:80",
 		"/ft/services/service-b/path-regex/content": "/content/.*",
 		"/ft/services/service-b/path-regex/bananas": "/bananas/.*",
+		"/ft/services/service-b/path-host/bananas": "custom-host",
 		"/ft/services/service-b/failover-predicate": "IsNetworkError()",
 	}); err != nil {
 		t.Error(err)
@@ -65,6 +66,9 @@ func TestReadServices(t *testing.T) {
 		PathPrefixes: map[string]string{
 			"bananas": "/bananas/.*",
 			"content": "/content/.*",
+		},
+		CustomHosts: map[string]string {
+			"bananas": "custom-host",
 		},
 		FailoverPredicate: "IsNetworkError()",
 	}
@@ -169,6 +173,9 @@ func TestBuildVulcanConfSingleBackend(t *testing.T) {
 			"bananas": "/bananas/.*",
 			"cheese":  "/cheese/.*",
 		},
+		CustomHosts: map[string]string {
+			"bananas": "custom-host",
+		},
 		FailoverPredicate: "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1",
 	}
 
@@ -232,7 +239,7 @@ func TestBuildVulcanConfSingleBackend(t *testing.T) {
 			},
 			"vcb-service-a-path-regex-bananas": vulcanFrontend{
 				BackendID:         "vcb-service-a",
-				Route:             "PathRegexp(`/bananas/.*`)",
+				Route:             "PathRegexp(`/bananas/.*`) && Host(`custom-host`)",
 				Type:              "http",
 				FailoverPredicate: "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1",
 			},

--- a/all_test.go
+++ b/all_test.go
@@ -67,7 +67,7 @@ func TestReadServices(t *testing.T) {
 			"bananas": "/bananas/.*",
 			"content": "/content/.*",
 		},
-		CustomHosts: map[string]string{
+		PathHosts: map[string]string{
 			"bananas": "custom-host",
 		},
 		FailoverPredicate: "IsNetworkError()",
@@ -173,7 +173,7 @@ func TestBuildVulcanConfSingleBackend(t *testing.T) {
 			"bananas": "/bananas/.*",
 			"cheese":  "/cheese/.*",
 		},
-		CustomHosts: map[string]string{
+		PathHosts: map[string]string{
 			"bananas": "custom-host",
 		},
 		FailoverPredicate: "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1",

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ type Service struct {
 	HasHealthCheck    bool
 	Addresses         map[string]string
 	PathPrefixes      map[string]string
-	CustomHosts       map[string]string
+	PathHosts         map[string]string
 	FailoverPredicate string
 }
 
@@ -108,7 +108,7 @@ func readServices(kapi client.KeysAPI) []Service {
 			Name:         filepath.Base(node.Key),
 			Addresses:    make(map[string]string),
 			PathPrefixes: make(map[string]string),
-			CustomHosts:  make(map[string]string),
+			PathHosts:    make(map[string]string),
 		}
 		for _, child := range node.Nodes {
 			switch filepath.Base(child.Key) {
@@ -124,7 +124,7 @@ func readServices(kapi client.KeysAPI) []Service {
 				}
 			case "path-host":
 				for _, path := range child.Nodes {
-					service.CustomHosts[filepath.Base(path.Key)] = path.Value
+					service.PathHosts[filepath.Base(path.Key)] = path.Value
 				}
 			case "failover-predicate":
 				service.FailoverPredicate = child.Value
@@ -260,7 +260,7 @@ func buildVulcanConf(kapi client.KeysAPI, services []Service) vulcanConf {
 
 		// public path front ends
 		for pathName, pathRegex := range service.PathPrefixes {
-			customHost, customHostExists := service.CustomHosts[pathName]
+			customHost, customHostExists := service.PathHosts[pathName]
 			var route string
 			if customHostExists {
 				route = fmt.Sprintf("PathRegexp(`%s`) && Host(`%s`)", pathRegex, customHost)

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ type Service struct {
 	HasHealthCheck    bool
 	Addresses         map[string]string
 	PathPrefixes      map[string]string
-	CustomHosts      map[string]string
+	CustomHosts       map[string]string
 	FailoverPredicate string
 }
 
@@ -105,10 +105,10 @@ func readServices(kapi client.KeysAPI) []Service {
 			continue
 		}
 		service := Service{
-			Name:              filepath.Base(node.Key),
-			Addresses:         make(map[string]string),
-			PathPrefixes:      make(map[string]string),
-			CustomHosts:      make(map[string]string),
+			Name:         filepath.Base(node.Key),
+			Addresses:    make(map[string]string),
+			PathPrefixes: make(map[string]string),
+			CustomHosts:  make(map[string]string),
 		}
 		for _, child := range node.Nodes {
 			switch filepath.Base(child.Key) {


### PR DESCRIPTION
Example:
```etcdctl set   /ft/services/service-a/path-regex/bar   /bar/.* ```
```etcdctl set   /ft/services/service-a/path-host/bar  public-host```
will result in
```
/vulcand/frontends/vcb-service-a-path-regex-bar/frontend  {"Type":"http", "BackendId":"vcb-service-a", "Route":"PathRegexp(`/bar/.*`) && Host(`public-host`)", "Settings": {"FailoverPredicate":""}}
```