### PR TITLE
Etcd load improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ADD  *.go /
+ADD  main.go /
 RUN apk add --update bash \
   && apk --update add go git\
   && ORG_PATH="github.com/Financial-Times" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ADD  main.go /
+ADD  *.go /
 RUN apk add --update bash \
   && apk --update add go git\
   && ORG_PATH="github.com/Financial-Times" \

--- a/all_test.go
+++ b/all_test.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/coreos/etcd/client"
 	etcderr "github.com/coreos/etcd/error"
 	"golang.org/x/net/context"
-	"reflect"
-	"testing"
 )
 
 func TestReadServices(t *testing.T) {

--- a/all_test.go
+++ b/all_test.go
@@ -90,13 +90,7 @@ func TestBuildInvalidServerVulcanConfSingleBackend(t *testing.T) {
 		FailoverPredicate: "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1",
 	}
 
-	etcd, err := client.New(client.Config{Endpoints: []string{"http://localhost:2379"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	kapi := client.NewKeysAPI(etcd)
-
-	vc := buildVulcanConf(kapi, []Service{a})
+	vc := buildVulcanConf([]Service{a})
 
 	expected := vulcanConf{
 		Backends: map[string]vulcanBackend{
@@ -180,13 +174,7 @@ func TestBuildVulcanConfSingleBackend(t *testing.T) {
 		FailoverPredicate: "(IsNetworkError() || ResponseCode() == 503 || ResponseCode() == 500) && Attempts() <= 1",
 	}
 
-	etcd, err := client.New(client.Config{Endpoints: []string{"http://localhost:2379"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	kapi := client.NewKeysAPI(etcd)
-
-	vc := buildVulcanConf(kapi, []Service{a})
+	vc := buildVulcanConf([]Service{a})
 
 	expected := vulcanConf{
 		Backends: map[string]vulcanBackend{

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	etcderr "github.com/coreos/etcd/error"
+	"github.com/kr/pretty"
 	"golang.org/x/net/context"
 	"golang.org/x/net/proxy"
 )
@@ -69,6 +70,7 @@ func main() {
 			log.Println("exiting")
 			return
 		case <-notifier.notify():
+			log.Println("Got notification")
 		}
 
 		//TODO parameterize log
@@ -497,10 +499,13 @@ func newNotifier(kapi client.KeysAPI, path string, socksProxy string, etcdPeers 
 
 			for err == nil {
 				response, err = watcher.Next(context.Background())
-				log.Printf("Watcher response: %# v", response)
+				log.Printf("Watcher response: %# v", pretty.Formatter(response))
+				//non-blocking send on a channel
 				select {
 				case w.ch <- struct{}{}:
+					log.Println("Sent message on notifier channel.")
 				default:
+					log.Println("Didn't send message on notifier channel.")
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -414,7 +414,7 @@ func cleanFrontends(kapi client.KeysAPI) {
 		panic(err)
 	}
 	if !resp.Node.Dir {
-		log.Print("/vulcand/frontends is not a directory.")
+		log.Println("/vulcand/frontends is not a directory.")
 		return
 	}
 	for _, fe := range resp.Node.Nodes {
@@ -448,7 +448,7 @@ func cleanBackends(kapi client.KeysAPI) {
 		panic(err)
 	}
 	if !resp.Node.Dir {
-		log.Print("/vulcand/backends is not a directory.")
+		log.Println("/vulcand/backends is not a directory.")
 		return
 	}
 	for _, be := range resp.Node.Nodes {

--- a/main.go
+++ b/main.go
@@ -495,7 +495,8 @@ func newNotifier(kapi client.KeysAPI, path string, socksProxy string, etcdPeers 
 			var err error
 
 			for err == nil {
-				_, err = watcher.Next(context.Background())
+				response, err = watcher.Next(context.Background())
+				log.Printf("Watcher response: %# v", response)
 				select {
 				case w.ch <- struct{}{}:
 				default:

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	etcderr "github.com/coreos/etcd/error"
+	"github.com/kr/pretty"
 	"golang.org/x/net/context"
 	"golang.org/x/net/proxy"
 )
@@ -105,7 +106,8 @@ func readServices(kapi client.KeysAPI) []Service {
 
 	var services []Service
 
-	log.Printf("Nodes read from etcd: %d", len(resp.Node.Nodes))
+	log.Printf("Nodes read from etcd: %# v", pretty.Formatter(resp))
+
 	for _, node := range resp.Node.Nodes {
 		if !node.Dir {
 			log.Printf("skipping non-directory %v\n", node.Key)

--- a/main.go
+++ b/main.go
@@ -493,6 +493,7 @@ func newNotifier(kapi client.KeysAPI, path string, socksProxy string, etcdPeers 
 			watcher := kapi.Watcher(path, &client.WatcherOptions{Recursive: true})
 
 			var err error
+			var response *client.Response
 
 			for err == nil {
 				response, err = watcher.Next(context.Background())

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 
 		//TODO parameterize log
-		log.Println("Change detected, waiting in cooldown period for 1 minute")
+		log.Println("Change detected, waiting in cooldown period")
 		// throttle
 		<-time.After(30 * time.Second)
 	}
@@ -83,6 +83,7 @@ func main() {
 
 func drainChannel(notifications <-chan uint64) {
 	readNotifications := true
+	log.Print("Draining notifications channel")
 	for readNotifications {
 		select {
 		case <-notifications:
@@ -90,6 +91,7 @@ func drainChannel(notifications <-chan uint64) {
 			readNotifications = false
 		}
 	}
+	log.Print("Finished draining notifications channel")
 }
 
 type Service struct {

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func readServices(kapi client.KeysAPI) []Service {
 
 	var services []Service
 
-	log.Printf("Nodes read from etcd: %# v", pretty.Formatter(resp))
+	log.Printf("Nodes read from etcd: %d", len(resp.Node.Nodes))
 
 	for _, node := range resp.Node.Nodes {
 		if !node.Dir {
@@ -119,6 +119,7 @@ func readServices(kapi client.KeysAPI) []Service {
 			PathPrefixes: make(map[string]string),
 			PathHosts:    make(map[string]string),
 		}
+		log.Printf("Service: \n %# v \n", pretty.Formatter(service))
 		for _, child := range node.Nodes {
 			switch filepath.Base(child.Key) {
 			case "healthcheck":

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/coreos/etcd/client"
 	etcderr "github.com/coreos/etcd/error"
-	"github.com/kr/pretty"
 	"golang.org/x/net/context"
 	"golang.org/x/net/proxy"
 )
@@ -55,8 +54,6 @@ func main() {
 
 	notifier := newNotifier(kapi, "/ft/services/", socksProxy, peers)
 
-	tick := time.NewTicker(30 * time.Second)
-
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 
@@ -76,7 +73,9 @@ func main() {
 
 		log.Println("Change detected, waiting in cooldown period for 30 secs")
 		// throttle
+		tick := time.NewTicker(30 * time.Second)
 		<-tick.C
+		tick.Stop()
 	}
 
 }
@@ -119,7 +118,7 @@ func readServices(kapi client.KeysAPI) []Service {
 			PathPrefixes: make(map[string]string),
 			PathHosts:    make(map[string]string),
 		}
-		log.Printf("Service: \n %# v \n", pretty.Formatter(service))
+		log.Printf("Name: %s", service.Name)
 		for _, child := range node.Nodes {
 			switch filepath.Base(child.Key) {
 			case "healthcheck":

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/coreos/etcd/client"
 	etcderr "github.com/coreos/etcd/error"
-	"github.com/kr/pretty"
 	"golang.org/x/net/context"
 	"golang.org/x/net/proxy"
 )
@@ -119,7 +118,6 @@ func readServices(kapi client.KeysAPI) []Service {
 			PathPrefixes: make(map[string]string),
 			PathHosts:    make(map[string]string),
 		}
-		log.Printf("Name: %s", service.Name)
 		for _, child := range node.Nodes {
 			switch filepath.Base(child.Key) {
 			case "healthcheck":
@@ -487,7 +485,7 @@ func vulcanConfToEtcdKeys(vc vulcanConf) map[string]string {
 }
 
 func newNotifier(kapi client.KeysAPI, path string, socksProxy string, etcdPeers []string) notifier {
-	w := notifier{make(chan struct{}, 1)}
+	w := notifier{make(chan struct{}, 0)}
 
 	go func() {
 
@@ -499,7 +497,7 @@ func newNotifier(kapi client.KeysAPI, path string, socksProxy string, etcdPeers 
 
 			for err == nil {
 				response, err = watcher.Next(context.Background())
-				log.Printf("Watcher response: %# v", pretty.Formatter(response))
+				log.Printf("Watcher response: %d", response.Index)
 				//non-blocking send on a channel
 				select {
 				case w.ch <- struct{}{}:

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 	cooldownPeriod          = os.Getenv("VCB_COOLDOWN_PERIOD")
 	notificationsBufferSize = os.Getenv("VCB_NOTIFICATIONS_BUFFER_SIZE")
 
-	addressRegex = regexp.MustCompile(`^[.\-:/\w]*:[0-9]{2,5}$`)
+	addressRegex = regexp.MustCompile(`^[\.\-:\/\w]*:[0-9]{2,5}$`)
 )
 
 func main() {


### PR DESCRIPTION
* adjusted notification mechanism to ignore change notifications which come in during the cooldown period -> vcb won't "run on empty", reducing the load on etcd
* parameterized cooldown period and notifications buffer size
* cooldown period directly affects how long sequential (zero-downtime) deployments will take as app startup depends on VCB
* small refactorings, logging improvements
* tests don't work on master, don't work on this branch either :(
* see it in action / try it out in the `vcb-work` cluster
